### PR TITLE
Add Docker configuration for backend and frontend

### DIFF
--- a/JMAirBack/Dockerfile
+++ b/JMAirBack/Dockerfile
@@ -1,0 +1,10 @@
+FROM gradle:8-jdk21 AS build
+WORKDIR /app
+COPY . .
+RUN gradle bootJar --no-daemon
+
+FROM openjdk:21-jdk
+WORKDIR /app
+COPY --from=build /app/build/libs/*.jar app.jar
+EXPOSE 8080
+ENTRYPOINT ["java","-jar","app.jar"]

--- a/JMAirBack/docker-compose.yml
+++ b/JMAirBack/docker-compose.yml
@@ -1,0 +1,26 @@
+version: '3.8'
+services:
+  db:
+    image: mysql:8.0
+    restart: always
+    environment:
+      MYSQL_ROOT_PASSWORD: password
+      MYSQL_DATABASE: jmair
+      MYSQL_USER: jmair
+      MYSQL_PASSWORD: jmair
+    volumes:
+      - db-data:/var/lib/mysql
+    ports:
+      - "3306:3306"
+  app:
+    build: .
+    depends_on:
+      - db
+    environment:
+      SPRING_DATASOURCE_URL: jdbc:mysql://db:3306/jmair
+      SPRING_DATASOURCE_USERNAME: jmair
+      SPRING_DATASOURCE_PASSWORD: jmair
+    ports:
+      - "8080:8080"
+volumes:
+  db-data:

--- a/JMAirFront/Dockerfile
+++ b/JMAirFront/Dockerfile
@@ -1,0 +1,20 @@
+FROM node:18 AS deps
+WORKDIR /app
+COPY package*.json ./
+RUN npm install
+
+FROM node:18 AS build
+WORKDIR /app
+COPY --from=deps /app/node_modules ./node_modules
+COPY . .
+RUN npm run build
+
+FROM node:18-alpine
+WORKDIR /app
+ENV NODE_ENV=production
+COPY --from=build /app/.next ./.next
+COPY --from=build /app/public ./public
+COPY --from=build /app/package*.json ./
+RUN npm install --production
+EXPOSE 3000
+CMD ["npm", "start"]

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,32 @@
+version: '3.8'
+services:
+  db:
+    image: mysql:8.0
+    restart: always
+    environment:
+      MYSQL_ROOT_PASSWORD: password
+      MYSQL_DATABASE: jmair
+      MYSQL_USER: jmair
+      MYSQL_PASSWORD: jmair
+    volumes:
+      - db-data:/var/lib/mysql
+    ports:
+      - "3306:3306"
+  backend:
+    build: ./JMAirBack
+    depends_on:
+      - db
+    environment:
+      SPRING_DATASOURCE_URL: jdbc:mysql://db:3306/jmair
+      SPRING_DATASOURCE_USERNAME: jmair
+      SPRING_DATASOURCE_PASSWORD: jmair
+    ports:
+      - "8080:8080"
+  frontend:
+    build: ./JMAirFront
+    depends_on:
+      - backend
+    ports:
+      - "3000:3000"
+volumes:
+  db-data:


### PR DESCRIPTION
## Summary
- add Dockerfile and compose for Spring Boot + MySQL in JMAirBack
- add Dockerfile for React frontend
- provide root compose file to run backend, frontend, and database together

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_685a82b27a9c8320bc66ad1a2753ba0f